### PR TITLE
Update GitHub repo URL to prod branch

### DIFF
--- a/app/(subpages)/about/page.tsx
+++ b/app/(subpages)/about/page.tsx
@@ -28,7 +28,7 @@ export const metadata = {
   },
 };
 
-const homepageRepoUrl = "https://github.com/kimyoonduk/dotcom";
+const homepageRepoUrl = "https://github.com/kimyoonduk/dotcom/tree/prod";
 
 const About = () => {
   return (

--- a/lib/get-projects.tsx
+++ b/lib/get-projects.tsx
@@ -14,7 +14,7 @@ const Projects: Project[] = [
     title: "kimYoonDuk.com",
     description: "Personal website and MDX blog.",
     href: "",
-    gitUrl: "https://github.com/kimyoonduk/dotcom",
+    gitUrl: "https://github.com/kimyoonduk/dotcom/tree/prod",
     role: "Creator",
     years: ["2023", "present"],
     tech: ["typescript", "react", "nextjs", "tailwind"],

--- a/posts/first-post.mdx
+++ b/posts/first-post.mdx
@@ -34,7 +34,7 @@ On the ML front, generative AI and language models are everyone's darling nowada
 My favorite approach to learning is to find good projects and reverse-engineer them.
 I took a lot of inspiration (and code snippets) from [Max Leiter's implementation](https://github.com/MaxLeiter/maxleiter.com) of an MDX blog using Next.js 13 and [John Smilga's examples](https://github.com/john-smilga/nextjs-course-openai) from his udemy course.
 
-A lot of the site functionality is still in the works. Feel free to track the progress on the [github repo](https://github.com/kimyoonduk/dotcom). Feature suggestions are always welcome. If you're reading this, you probably know how to reach me.
+A lot of the site functionality is still in the works. Feel free to track the progress on the [github repo](https://github.com/kimyoonduk/dotcom/tree/prod). Feature suggestions are always welcome. If you're reading this, you probably know how to reach me.
 
 Stay warm!
 


### PR DESCRIPTION
This pull request updates the GitHub repository URL in the code to point to the prod branch instead of the main branch. This ensures that the correct branch is referenced for the repository.