### PR TITLE
Update .gitignore and landing page post count

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ kimyoondukdotcom.code-workspace
 app/about/page_temp.tsx
 .env
 in_progress/*
+posts/_*

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,7 +21,7 @@ export default function Home() {
         <div className="py-4">
           <h2 className="text-2xl font-bold mb-4">Recent Posts</h2>
           <Suspense fallback={<div>Loading...</div>}>
-            <PostListRSC paginate={true} displayCount={3} />
+            <PostListRSC paginate={true} displayCount={5} />
           </Suspense>
         </div>
       </div>


### PR DESCRIPTION
This pull request updates the .gitignore file to include the "in_progress/*" and "posts/_*" patterns. It also updates the landing page to display 5 recent posts instead of 3.