### PR TITLE
Fix typo in karaoke-index.mdx

### DIFF
--- a/posts/karaoke-index.mdx
+++ b/posts/karaoke-index.mdx
@@ -7,7 +7,7 @@ tags: ['south korea', 'noraebang']
 ---
 
 There are a lot of things I miss about Seoul, but the Korean coin-karaoke holds a spot near the top of that list. The original Japanese term "karaoke" translates to the poetic, "empty orchestra".
-In Korea, karaoke goes by a more straightforward, "noraebang", a compound of 노래(song) and 방(room).
+In Korea, karaoke goes by a more straightforward, "noraebang", a compound word of 노래(song) and 방(room).
 As the name implies, noraebang is a space where singing takes center stage.
 
 Absent are the interruptions of food service or the company of cheerful drunk strangers.
@@ -24,7 +24,7 @@ Humans have been singing for a long time. Hell, even birds and crickets "sing".
 Perhaps it's in our nature to belt out some outdated top-40 hits.
 In that context, "singing space" could be construed a critical infrastructure for emotional release, a toilet for the soul, if you will.
 
-In a densely populated metropolis like Seoul, private space is a rare commodity as it leisure time.
+In a densely populated metropolis like Seoul, private space is a rare commodity as is leisure time.
 South Korea is notorious for its lengthy work hours, as highlighted by the [OECD data](https://data.oecd.org/emp/hours-worked.htm).
 
 I think therein lies the source of the karaoke disparity between the US and Korea.


### PR DESCRIPTION
This pull request fixes a typo in the karaoke-index.mdx file. The word "is" was changed to "as" in line 24.